### PR TITLE
build v0.2.4:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,21 +10,23 @@ source:
   sha256: e58abc4539184a65faf9956957d3787616bedeb1303ac5c9b1a201d8af6b87d7
 
 build:
-  noarch: python
+  skip: true  # [py<36 or s390x]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
-    - triad
+    - python
+    - triad >=0.6.1
 
 test:
   imports:
-    - triad
+    - adagio
   requires:
     - pip
   commands:
@@ -33,8 +35,12 @@ test:
 about:
   home: https://github.com/fugue-project/adagio
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   summary: A Dag IO framework for Fugue projects.
+  description: A Dag IO framework for Fugue projects.
+  dev_url: https://github.com/fugue-project/adagio/tree/0.2.4
+  doc_url: https://github.com/fugue-project/adagio/blob/0.2.4/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,8 @@ about:
   license_file: LICENSE
   summary: A Dag IO framework for Fugue projects.
   description: A Dag IO framework for Fugue projects.
-  dev_url: https://github.com/fugue-project/adagio/tree/0.2.4
-  doc_url: https://github.com/fugue-project/adagio/blob/0.2.4/README.md
+  dev_url: https://github.com/fugue-project/adagio
+  doc_url: https://github.com/fugue-project/adagio/blob/master/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: e58abc4539184a65faf9956957d3787616bedeb1303ac5c9b1a201d8af6b87d7
 
 build:
+  # triad is missing on s390x. 
   skip: true  # [py<36 or s390x]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv


### PR DESCRIPTION
 - noarch removed.
 - build script updated.
 - host dependencies updated.
 - pinnings in run dependencies updated.
 - 'about' section updated with missing info.